### PR TITLE
Web socket

### DIFF
--- a/Assets/WalletConnectUnity/Scripts/WalletConnectSharp.Unity/Network/Client/WebSocket.cs
+++ b/Assets/WalletConnectUnity/Scripts/WalletConnectSharp.Unity/Network/Client/WebSocket.cs
@@ -561,7 +561,7 @@ namespace NativeWebSocket
                 if (!Monitor.TryEnter(m_Socket, 1000))
                 {
                     // If we couldn't obtain exclusive access to the socket in one second, something is wrong.
-                    await m_Socket.CloseAsync(WebSocketCloseStatus.InternalServerError, string.Empty, m_CancellationToken);
+                    await m_Socket.CloseOutputAsync(WebSocketCloseStatus.InternalServerError, string.Empty, m_CancellationToken);
                     return;
                 }
 
@@ -649,7 +649,7 @@ namespace NativeWebSocket
             ArraySegment<byte> buffer = new ArraySegment<byte>(new byte[8192]);
             try
             {
-                while (m_Socket.State == System.Net.WebSockets.WebSocketState.Open)
+                while (m_Socket.State == System.Net.WebSockets.WebSocketState.Open || m_Socket.State == System.Net.WebSockets.WebSocketState.CloseSent)
                 {
                     WebSocketReceiveResult result = null;
 
@@ -708,7 +708,7 @@ namespace NativeWebSocket
         {
             if (State == WebSocketState.Open)
             {
-                await m_Socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, m_CancellationToken);
+                await m_Socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, m_CancellationToken);
             }
         }
     }

--- a/Assets/WalletConnectUnity/Scripts/WalletConnectSharp.Unity/Network/NativeWebSocketTransport.cs
+++ b/Assets/WalletConnectUnity/Scripts/WalletConnectSharp.Unity/Network/NativeWebSocketTransport.cs
@@ -31,7 +31,7 @@ namespace WalletConnectSharp.Unity.Network
         {
             get
             {
-                return client != null && client.State == WebSocketState.Open && opened;
+                return client != null && (client.State == WebSocketState.Open || client.State == WebSocketState.Closing) && opened;
             }
         }
 


### PR DESCRIPTION
Using `CloseAsync` is not correct way to close a WebSocket from the client side:

> When you’re writing client WebSocket code and the client wants to intiate the shutdown, call CloseOutputAsync. This transitions the socket to the CloseSent state, which appears to be required to transition to the Closed state when the server replies. You should also watch the socket state until it is actually closed.

> When you’re writing server WebSocket code and the server wants to initiate the shutdown, call CloseAsync. This handles the entire closing handshake flow correctly.

Source: https://mcguirev10.com/2019/08/17/how-to-close-websocket-correctly.html