### PR TITLE
Fixed use Session.SessionConnected to see if the WalletConnect Session is connected instead of Session.Connected

### DIFF
--- a/Assets/WalletConnectUnity/Scripts/WalletConnectSharp.Unity/WalletConnect.cs
+++ b/Assets/WalletConnectUnity/Scripts/WalletConnectSharp.Unity/WalletConnect.cs
@@ -174,7 +174,7 @@ namespace WalletConnectSharp.Unity
                         {
                             if (currentKey != savedSession.Key)
                             {
-                                if (Session.Connected)
+                                if (Session.SessionConnected)
                                 {
                                     await Session.Disconnect();
                                 }
@@ -196,7 +196,7 @@ namespace WalletConnectSharp.Unity
                                 return null; //Nothing to do
                             }
                         }
-                        else if (Session.Connected)
+                        else if (Session.SessionConnected)
                         {
                             await Session.Disconnect();
                         }


### PR DESCRIPTION
Session.Connected checks both SessionConnected and TransportConnected. If we only want to check the WalletConnect Session use Session.SessionConnected