### PR TITLE
Initalize uri as empty string before splitting into directive-only paths

### DIFF
--- a/Assets/WalletConnectUnity/Scripts/WalletConnectUnity/Models/Wallet.cs
+++ b/Assets/WalletConnectUnity/Scripts/WalletConnectUnity/Models/Wallet.cs
@@ -64,7 +64,7 @@ namespace WalletConnectUnity.Models
 
         public void OpenDeeplink(ConnectedData data, bool useNative = false)
         {
-            string uri;
+            string uri = string.Empty;
             #if UNITY_ANDROID
             uri = data.Uri; // Android OS should handle wc: protocol 
             #elif UNITY_IOS


### PR DESCRIPTION
Prevent compiler error CS0165 "Use of unassigned variable"