### PR TITLE
fix: SignClient disposing when duplicate WalletConnectModal deletion occurs

### DIFF
--- a/Packages/com.walletconnect.modal/Runtime/WalletConnectModal.cs
+++ b/Packages/com.walletconnect.modal/Runtime/WalletConnectModal.cs
@@ -152,7 +152,10 @@ namespace WalletConnectUnity.Modal
 
         private void OnDestroy()
         {
-            SignClient?.Dispose();
+            if (Instance == this)
+            {
+                SignClient?.Dispose();
+            }
         }
     }
 


### PR DESCRIPTION
This pull request fixes the issue in #199